### PR TITLE
Fix lint issues

### DIFF
--- a/src/nodetool/dsl/lib/numpy/arithmetic.py
+++ b/src/nodetool/dsl/lib/numpy/arithmetic.py
@@ -1,8 +1,5 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
+from pydantic import Field
 import nodetool.metadata.types
-import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 
 

--- a/src/nodetool/dsl/lib/numpy/conversion.py
+++ b/src/nodetool/dsl/lib/numpy/conversion.py
@@ -1,7 +1,5 @@
-from pydantic import BaseModel, Field
-import typing
+from pydantic import Field
 from typing import Any
-import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/numpy/io.py
+++ b/src/nodetool/dsl/lib/numpy/io.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/numpy/manipulation.py
+++ b/src/nodetool/dsl/lib/numpy/manipulation.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/numpy/math.py
+++ b/src/nodetool/dsl/lib/numpy/math.py
@@ -1,6 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
+from pydantic import Field
 import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode

--- a/src/nodetool/dsl/lib/numpy/reshaping.py
+++ b/src/nodetool/dsl/lib/numpy/reshaping.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/numpy/statistics.py
+++ b/src/nodetool/dsl/lib/numpy/statistics.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/numpy/utils.py
+++ b/src/nodetool/dsl/lib/numpy/utils.py
@@ -1,8 +1,5 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
+from pydantic import Field
 import nodetool.metadata.types
-import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 
 

--- a/src/nodetool/dsl/lib/numpy/visualization.py
+++ b/src/nodetool/dsl/lib/numpy/visualization.py
@@ -1,6 +1,5 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
 import typing
-from typing import Any
 import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode

--- a/src/nodetool/dsl/lib/seaborn.py
+++ b/src/nodetool/dsl/lib/seaborn.py
@@ -1,7 +1,5 @@
-from pydantic import BaseModel, Field
-import typing
+from pydantic import Field
 from typing import Any
-import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/nodes/lib/numpy/reshaping.py
+++ b/src/nodetool/nodes/lib/numpy/reshaping.py
@@ -1,4 +1,3 @@
-import numpy as np
 from pydantic import Field
 from nodetool.workflows.processing_context import ProcessingContext
 from nodetool.workflows.base_node import BaseNode

--- a/src/nodetool/nodes/lib/numpy/visualization.py
+++ b/src/nodetool/nodes/lib/numpy/visualization.py
@@ -1,4 +1,3 @@
-import numpy as np
 from io import BytesIO
 from enum import Enum
 from pydantic import Field

--- a/src/nodetool/nodes/lib/seaborn.py
+++ b/src/nodetool/nodes/lib/seaborn.py
@@ -15,18 +15,11 @@ from pydantic import Field
 import matplotlib
 
 matplotlib.use("Agg")
-from matplotlib import pyplot as plt
 import io
 import pandas as pd
 
 
 from typing import Any
-from pydantic import Field
-from nodetool.metadata.types import (
-    ImageRef,
-)
-from nodetool.workflows.base_node import BaseNode
-from nodetool.workflows.processing_context import ProcessingContext
 
 
 class SeabornStyle(str, Enum):

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -4,7 +4,6 @@ from nodetool.workflows.processing_context import ProcessingContext
 from nodetool.metadata.types import (
     ColumnDef,
     DataframeRef,
-    FolderRef,
 )
 from nodetool.nodes.nodetool.data import (
     SelectColumn,

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,8 +1,6 @@
 import pytest
 import numpy as np
-from unittest.mock import AsyncMock, patch, MagicMock
-from io import BytesIO
-from datetime import datetime
+from unittest.mock import patch
 from PIL import Image
 import io
 
@@ -16,7 +14,6 @@ from nodetool.nodes.lib.numpy import (
     CosineArray,
     PowerArray,
     SqrtArray,
-    SaveArray,
     ConvertToArray,
     ConvertToImage,
     ConvertToAudio,
@@ -46,7 +43,7 @@ from nodetool.nodes.lib.numpy import (
     SplitArray,
 )
 from nodetool.workflows.processing_context import ProcessingContext
-from nodetool.metadata.types import NPArray, ImageRef, AudioRef, FolderRef
+from nodetool.metadata.types import NPArray, ImageRef, AudioRef
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- remove unused imports in DSL modules
- drop unused imports from tests
- clean up Seaborn node imports

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nodetool.dsl.nodetool')*